### PR TITLE
Backwards compatible Qt5 updates

### DIFF
--- a/src/Qt/SudokuElement.cpp
+++ b/src/Qt/SudokuElement.cpp
@@ -29,7 +29,7 @@ SudokuElement::SudokuElement(void) {
     for (int i = 0; i < 9; i++)
         m_choices[i] = false;
 
-    setAcceptsHoverEvents(true);
+    setAcceptHoverEvents(true);
     setFlag(QGraphicsItem::ItemIsFocusable);
 }
 

--- a/src/Qt/SudokuScene.cpp
+++ b/src/Qt/SudokuScene.cpp
@@ -174,7 +174,7 @@ void SudokuScene::resizeScene(int width, int height) {
     QGraphicsItem * item;
     foreach (item, this->items()) {
         item->setPos(item->pos() * scaledScale);
-        item->scale(scaledScale, scaledScale);
+        item->setScale(scale);
     }
 
     m_currentScale = scale;
@@ -263,7 +263,7 @@ void SudokuScene::animationStep(void) {
  */
 void SudokuScene::pause(bool paused) {
     if (!m_paused && paused) {
-        m_pauseOverlay->scale(m_currentScale, m_currentScale);
+        m_pauseOverlay->setScale(m_currentScale);
         addItem(m_pauseOverlay);
         installEventFilter(m_filter);
         update(QRectF(0, 0, Dimensions::boardSize, Dimensions::boardSize));
@@ -271,7 +271,7 @@ void SudokuScene::pause(bool paused) {
     else if (m_paused && !paused) {
         removeItem(m_pauseOverlay);
         double scaleBack = 1.0 / m_currentScale;
-        m_pauseOverlay->scale(scaleBack, scaleBack);
+        m_pauseOverlay->setScale(scaleBack);
         removeEventFilter(m_filter);
         update(QRectF(0, 0, Dimensions::boardSize, Dimensions::boardSize));
     }

--- a/src/Sudoku_shared.pri
+++ b/src/Sudoku_shared.pri
@@ -13,6 +13,7 @@ CONFIG(release, debug|release) {
 message("Basic settings...")
 TEMPLATE = app
 CONFIG += qt thread resources warn_on
+QT += printsupport
 OBJECTS_DIR = .obj
 MOC_DIR = .moc
 RCC_DIR = .rcc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,10 @@ using namespace std;
 int main(int argc, char * argv[]) {
     QT_REQUIRE_VERSION(argc, argv, "4.3.0")
 
+    #if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
+        QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    #endif
+
     try {
         SudokuApp app(argc, argv);
         return app.exec();


### PR DESCRIPTION
Compiled and tested under Ubuntu 20.04 with main qt5 libraries and [PPA rock core](https://launchpad.net/%7Erock-core/+archive/ubuntu/qt4/) qt4 libraries without issue.

Also a high DPI display nice to have for Qt 5.6+ which [might not work with OpenGL](https://vicrucann.github.io/tutorials/osg-qt-high-dpi/).